### PR TITLE
632: Convert UpdateProductFromMiniShoppingCartEntityTest to MFTF

### DIFF
--- a/app/code/Magento/Catalog/Test/Mftf/Data/ProductData.xml
+++ b/app/code/Magento/Catalog/Test/Mftf/Data/ProductData.xml
@@ -869,4 +869,20 @@
         <requiredEntity type="product_extension_attribute">EavStockItem</requiredEntity>
         <requiredEntity type="custom_attribute_array">CustomAttributeCategoryIds</requiredEntity>
     </entity>
+    <entity name="simpleProductWithoutCategory" type="product">
+        <data key="sku" unique="suffix">sku_simple_product_</data>
+        <data key="type_id">simple</data>
+        <data key="attribute_set_id">4</data>
+        <data key="visibility">4</data>
+        <data key="name" unique="suffix">SimpleProduct</data>
+        <data key="price">560</data>
+        <data key="urlKey" unique="suffix">simple-product-</data>
+        <data key="status">1</data>
+        <data key="quantity">25</data>
+        <data key="weight">1</data>
+        <data key="product_has_weight">1</data>
+        <data key="is_in_stock">1</data>
+        <data key="tax_class_id">2</data>
+        <requiredEntity type="product_extension_attribute">EavStockItem</requiredEntity>
+    </entity>
 </entities>

--- a/app/code/Magento/Checkout/Test/Mftf/ActionGroup/ShoppingCartCheckSummaryTotalActionGroup.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/ActionGroup/ShoppingCartCheckSummaryTotalActionGroup.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="ShoppingCartCheckSummaryTotalActionGroup">
+        <arguments>
+            <argument name="dataQuote" type="entity"/>
+        </arguments>
+        <waitForPageLoad stepKey="waitForPageLoad" time="120"/>
+        <grabTextFrom selector="{{CheckoutCartSummarySection.total}}" stepKey="grabCartTotal" />
+        <assertContains stepKey="assertCartTotal">
+            <actualResult type="variable">$grabCartTotal</actualResult>
+            <expectedResult type="string">{{dataQuote.total}}</expectedResult>
+        </assertContains>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Checkout/Test/Mftf/Data/QuoteData.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Data/QuoteData.xml
@@ -15,4 +15,12 @@
         <data key="total">495.00</data>
         <data key="shippingMethod">Flat Rate - Fixed</data>
     </entity>
+    <entity name="simpleOrderQty2" type="Quote">
+        <data key="price">560.00</data>
+        <data key="qty">2</data>
+        <data key="subtotal">1,120.00</data>
+        <data key="shipping">10.00</data>
+        <data key="total">1,130.00</data>
+        <data key="shippingMethod">Flat Rate - Fixed</data>
+    </entity>
 </entities>

--- a/app/code/Magento/Checkout/Test/Mftf/Test/UpdateProductFromMiniShoppingCartEntityTest.xml
+++ b/app/code/Magento/Checkout/Test/Mftf/Test/UpdateProductFromMiniShoppingCartEntityTest.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="UpdateProductFromMiniShoppingCartEntityTest">
+        <annotations>
+            <stories value="Shopping Cart"/>
+            <title value="Check updating product from mini shopping cart"/>
+            <description value="Update Product Qty on Mini Shopping Cart"/>
+            <severity value="MAJOR"/>
+            <testCaseId value="MAGETWO-29812"/>
+            <group value="shoppingCart"/>
+            <group value="mtf_migrated"/>
+        </annotations>
+
+        <before>
+            <!--Create product according to dataset.-->
+            <createData entity="simpleProductWithoutCategory" stepKey="createProduct"/>
+
+            <!-- Go to frontend -->
+            <amOnPage url="{{StorefrontProductPage.url($$createProduct.name$$)}}" stepKey="navigateToProductPage"/>
+
+            <!--Add product to cart-->
+            <actionGroup ref="addToCartFromStorefrontProductPage" stepKey="addToCartFromStorefrontProductPage">
+                <argument name="productName" value="$$createProduct.name$$"/>
+            </actionGroup>
+        </before>
+
+        <after>
+            <!--Delete created data-->
+            <deleteData createDataKey="createProduct" stepKey="deleteProduct" />
+        </after>
+
+        <!-- Click on mini shopping cart icon -->
+        <click selector="{{StorefrontMinicartSection.showCart}}" stepKey="goToMiniShoppingCart"/>
+
+        <!-- Click Edit -->
+        <click selector="{{StorefrontMinicartSection.viewAndEditCart}}" stepKey="editMiniCartItem"/>
+
+        <!-- Fill data from dataset -->
+        <clearField selector="{{CheckoutCartProductSection.ProductQuantityByName($$createProduct.name$$)}}" stepKey="deleteFiled"/>
+        <fillField selector="{{CheckoutCartProductSection.ProductQuantityByName($$createProduct.name$$)}}"  userInput="{{simpleOrderQty2.qty}}" stepKey="changeQty"/>
+
+        <!-- Click Update -->
+        <click selector="{{CheckoutCartProductSection.updateShoppingCartButton}}" stepKey="updateQty"/>
+
+        <!-- Perform all assertions -->
+        <actionGroup ref="ShoppingCartCheckSummaryTotalActionGroup" stepKey="checkSummary">
+            <argument name="dataQuote" value="simpleOrderQty2"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/dev/tests/functional/tests/app/Magento/Checkout/Test/TestCase/UpdateProductFromMiniShoppingCartEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Checkout/Test/TestCase/UpdateProductFromMiniShoppingCartEntityTest.xml
@@ -9,7 +9,7 @@
     <testCase name="Magento\Checkout\Test\TestCase\UpdateProductFromMiniShoppingCartEntityTest" summary="Update Product from Mini Shopping Cart" ticketId="MAGETWO-29812">
         <variation name="UpdateProductFromMiniShoppingCartEntityTestVariation1" summary="Update Product Qty on Mini Shopping Cart" ticketId=" MAGETWO-35536">
             <data name="issue" xsi:type="string">https://github.com/magento-engcom/msi/issues/1624</data>
-            <data name="tag" xsi:type="string">test_type:extended_acceptance_test, severity:S0</data>
+            <data name="tag" xsi:type="string">test_type:extended_acceptance_test, severity:S0, mftf_migrated:yes</data>
             <data name="originalProduct/0" xsi:type="string">catalogProductSimple::default</data>
             <data name="checkoutData/dataset" xsi:type="string">simple_order_qty_2</data>
             <data name="use_minicart_to_edit_qty" xsi:type="boolean">true</data>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
### Test Case
[Magento\Checkout\Test\TestCase\UpdateProductFromMiniShoppingCartEntityTest ](https://github.com/magento/magento-functional-tests-migration/tree/2.3-develop/dev/tests/functional/tests/app/Magento/Checkout/Test/TestCase/UpdateProductFromMiniShoppingCartEntityTest.php)

### Variations to be converted:
[UpdateProductFromMiniShoppingCartEntityTestVariation1](https://github.com/magento/magento-functional-tests-migration/tree/2.3-develop/dev/tests/functional/tests/app/Magento/Checkout/Test/TestCase/UpdateProductFromMiniShoppingCartEntityTest.xml#L10)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues 
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento-functional-tests-migration#632: Convert UpdateProductFromMiniShoppingCartEntityTest to MFTF

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
