### PR TITLE
Convert CaptchaOnStoreFrontRegisterTest to MFTF

### DIFF
--- a/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaOnStoreFrontRegisterTest.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaOnStoreFrontRegisterTest.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="CaptchaOnStoreFrontRegisterTest">
+        <annotations>
+            <features value="Captcha"/>
+            <stories value="Test creation for customer register with captcha on storefront."/>
+            <title value="Captcha customer registration"/>
+            <description value="Test creation for customer register with captcha on storefront."/>
+            <severity value="MAJOR"/>
+            <group value="captcha"/>
+            <group value="mtf_migrated"/>
+        </annotations>
+        <before>
+            <!--  Enable captcha for customer. -->
+            <magentoCLI command="config:set customer/captcha/forms user_create" stepKey="enableUserRegistrationCaptcha"/>
+            <magentoCLI command="cache:clean config full_page" stepKey="cleanInvalidatedCaches1"/>
+        </before>
+        <after>
+            <!-- Set default configuration. -->
+            <magentoCLI command="config:set customer/captcha/forms user_login,user_forgotpassword" stepKey="revertCaptchaConfigurations"/>
+            <magentoCLI command="cache:clean config full_page" stepKey="cleanInvalidatedCaches2"/>
+        </after>
+
+        <!-- Open Customer registration page -->
+        <amOnPage url="/customer/account/create/" stepKey="goToRegistrationPage"/>
+        <waitForPageLoad stepKey="waitForRegistrationPage"/>
+
+        <!-- Check captcha visibility registration page load -->
+        <waitForElementVisible selector="{{StorefrontCustomerCreateFormSection.captchaField}}" stepKey="seeCaptchaField"/>
+        <waitForElementVisible selector="{{StorefrontCustomerCreateFormSection.captchaImg}}" stepKey="seeCaptchaImage"/>
+        <waitForElementVisible selector="{{StorefrontCustomerCreateFormSection.captchaReload}}" stepKey="seeCaptchaReloadButton"/>
+
+        <!-- Submit form with incorrect captcha -->
+        <fillField  selector="{{StorefrontCustomerCreateFormSection.firstnameField}}" userInput="FirstName"  stepKey="fillFirstName"/>
+        <fillField  selector="{{StorefrontCustomerCreateFormSection.lastnameField}}" userInput="LastName" stepKey="fillLastName" />
+        <fillField  stepKey="fillEmail" userInput="email@example.com" selector="{{StorefrontCustomerCreateFormSection.emailField}}"/>
+        <fillField  stepKey="fillPassword" userInput="123123Qq" selector="{{StorefrontCustomerCreateFormSection.passwordField}}"/>
+        <fillField  stepKey="fillConfirmPassword" userInput="123123Qq" selector="{{StorefrontCustomerCreateFormSection.confirmPasswordField}}"/>
+        <fillField selector="{{StorefrontCustomerCreateFormSection.captchaField}}" userInput="wrongCaptcha" stepKey="enterWrongCaptcha"/>
+        <click stepKey="clickCreateAccountButton" selector="{{StorefrontCustomerCreateFormSection.createAccountButton}}"/>
+        <see userInput="Incorrect CAPTCHA" selector="{{StorefrontCustomerMessagesSection.errorMessage}}" stepKey="verifyMessage4"/>
+    </test>
+</tests>

--- a/app/code/Magento/Customer/Test/Mftf/Section/StorefrontCustomerCreateFormSection.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Section/StorefrontCustomerCreateFormSection.xml
@@ -17,6 +17,9 @@
         <element name="passwordField" type="input" selector="#password"/>
         <element name="confirmPasswordField" type="input" selector="#password-confirmation"/>
         <element name="createAccountButton" type="button" selector="button.action.submit.primary" timeout="30"/>
+        <element name="captchaField" type="input" selector="#captcha_user_create"/>
+        <element name="captchaImg" type="block" selector=".captcha-img"/>
+        <element name="captchaReload" type="block" selector=".captcha-reload"/>
     </section>
     <section name="StoreFrontCustomerAdvancedAttributesSection">
         <element name="textFieldAttribute" type="input" selector="//input[@id='{{var}}']" parameterized="true" />


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR with a test that checks captcha on the customer registration page.
Steps:

Preconditions:

Enable CAPTCHA for customer register page.
Test Flow:

 1. Open storefront customer registration form.
 2. Register customer using captcha.

### Fixed Issues
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
Convert CaptchaOnStoreFrontRegisterTest to MFTF #244



 
