### PR TITLE
Convert CaptchaOnStoreFrontLoginTest to MFTF

### DIFF
--- a/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaOnStoreFrontLoginTest.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaOnStoreFrontLoginTest.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="CaptchaOnStoreFrontLoginTest">
+        <annotations>
+            <features value="Captcha"/>
+            <stories value="Check CAPTCHA on Storefront Login Page."/>
+            <title value="Captcha customer login page test"/>
+            <description value="Check CAPTCHA on Storefront Login Page."/>
+            <severity value="MAJOR"/>
+            <group value="captcha"/>
+            <group value="mtf_migrated"/>
+        </annotations>
+        <before>
+            <createData entity="Simple_US_Customer" stepKey="customer"/>
+        </before>
+        <after>
+            <deleteData createDataKey="customer" stepKey="deleteCustomer"/>
+        </after>
+
+        <!-- Open storefront login form -->
+        <amOnPage url="{{StorefrontCustomerSignInPage.url}}" stepKey="amOnSignInPage"/>
+        <waitForPageLoad stepKey="waitForStorefrontLoginPage"/>
+
+        <!-- Login with wrong credentials 3 times -->
+        <fillField selector="{{StorefrontCustomerSignInFormSection.emailField}}"  userInput="$$customer.email$$" stepKey="fillEmail1"/>
+        <fillField selector="{{StorefrontCustomerSignInFormSection.passwordField}}" userInput="$$customer.password$$INVALID" stepKey="fillPassword1" />
+        <click selector="{{StorefrontCustomerSignInFormSection.signInAccountButton}}" stepKey="clickSignInAccountButton1"/>
+        <see selector="{{StorefrontCustomerLoginMessagesSection.errorMessage}}" userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later." stepKey="seeErrorMessage1" />
+        <dontSee selector="StorefrontCustomerSignInFormSection.captchaField" stepKey="dontSeeCaptchaInputField1"/>
+
+        <fillField selector="{{StorefrontCustomerSignInFormSection.emailField}}"  userInput="$$customer.email$$" stepKey="fillEmail2"/>
+        <fillField selector="{{StorefrontCustomerSignInFormSection.passwordField}}" userInput="$$customer.password$$INVALID" stepKey="fillPassword2" />
+        <click selector="{{StorefrontCustomerSignInFormSection.signInAccountButton}}" stepKey="clickSignInAccountButton2"/>
+        <see selector="{{StorefrontCustomerLoginMessagesSection.errorMessage}}" userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later." stepKey="seeErrorMessage2" />
+        <dontSee selector="StorefrontCustomerSignInFormSection.captchaField" stepKey="dontSeeCaptchaInputField2"/>
+
+        <fillField selector="{{StorefrontCustomerSignInFormSection.emailField}}"  userInput="$$customer.email$$" stepKey="fillEmail3"/>
+        <fillField selector="{{StorefrontCustomerSignInFormSection.passwordField}}" userInput="$$customer.password$$INVALID" stepKey="fillPassword3" />
+        <click selector="{{StorefrontCustomerSignInFormSection.signInAccountButton}}" stepKey="clickSignInAccountButton3"/>
+        <see selector="{{StorefrontCustomerLoginMessagesSection.errorMessage}}" userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later." stepKey="seeErrorMessage3" />
+
+        <!-- Check captcha visibility on login page  -->
+        <waitForElementVisible selector="{{StorefrontCustomerSignInFormSection.captchaField}}" stepKey="seeCaptchaField"/>
+        <waitForElementVisible selector="{{StorefrontCustomerSignInFormSection.captchaImg}}" stepKey="seeCaptchaImage"/>
+        <waitForElementVisible selector="{{StorefrontCustomerSignInFormSection.captchaReload}}" stepKey="seeCaptchaReloadButton"/>
+
+        <!-- Submit form with incorrect captcha -->
+        <fillField selector="{{StorefrontCustomerSignInFormSection.emailField}}"  userInput="$$customer.email$$" stepKey="fillEmail4"/>
+        <fillField selector="{{StorefrontCustomerSignInFormSection.passwordField}}" userInput="$$customer.password$$INVALID" stepKey="fillPassword4" />
+        <fillField selector="{{StorefrontCustomerSignInFormSection.captchaField}}" userInput="InvalidCaptcha" stepKey="fillCaptcha" />
+        <click selector="{{StorefrontCustomerSignInFormSection.signInAccountButton}}" stepKey="clickSignInAccountButton4"/>
+        <see userInput="Incorrect CAPTCHA" selector="{{StorefrontCustomerMessagesSection.errorMessage}}" stepKey="verifyMessage4"/>
+    </test>
+</tests>

--- a/app/code/Magento/Customer/Test/Mftf/Section/StorefrontCustomerSignInFormSection.xml
+++ b/app/code/Magento/Customer/Test/Mftf/Section/StorefrontCustomerSignInFormSection.xml
@@ -13,6 +13,9 @@
         <element name="passwordField" type="input" selector="#pass"/>
         <element name="signInAccountButton" type="button" selector="#send2" timeout="30"/>
         <element name="forgotPasswordLink" type="link" selector=".action.remind" timeout="10"/>
+        <element name="captchaField" type="input" selector="#captcha_user_login"/>
+        <element name="captchaImg" type="block" selector=".captcha-img"/>
+        <element name="captchaReload" type="block" selector=".captcha-reload"/>
     </section>
     <section name="StorefrontCustomerSignInPopupFormSection">
         <element name="errorMessage" type="input" selector="[data-ui-id='checkout-cart-validationmessages-message-error']"/>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR with a test that checks captcha and lockout on the customer login page.
Steps:

Preconditions:
 1. Create customer.

Test Flow:
1. Open storefront login form.
2. Log in using invalid credentials 
3. Check captcha.

### Fixed Issues 
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #245 Convert CaptchaOnStoreFrontLoginTest to MFTF

