### PR TITLE
Convert CaptchaOnContactUsTest to MFTF

### DIFF
--- a/app/code/Magento/Captcha/Test/Mftf/Section/StorefrontContactUsCaptchaSection.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/Section/StorefrontContactUsCaptchaSection.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="StorefrontContactUsCaptchaSection">
+        <element name="captchaField" type="input" selector="#captcha_contact_us"/>
+        <element name="captchaImg" type="block" selector=".captcha-img"/>
+        <element name="captchaReload" type="block" selector=".captcha-reload"/>
+        <element name="nameField" type="input" selector="#name"/>
+        <element name="emailField" type="input" selector="#email"/>
+        <element name="commentField" type="textarea" selector="#comment"/>
+        <element name="submitFormButton" type="button" selector=".action.submit.primary" timeout="30"/>
+    </section>
+</sections>

--- a/app/code/Magento/Captcha/Test/Mftf/Section/StorefrontContactUsCaptchaSection.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/Section/StorefrontContactUsCaptchaSection.xml
@@ -12,9 +12,5 @@
         <element name="captchaField" type="input" selector="#captcha_contact_us"/>
         <element name="captchaImg" type="block" selector=".captcha-img"/>
         <element name="captchaReload" type="block" selector=".captcha-reload"/>
-        <element name="nameField" type="input" selector="#name"/>
-        <element name="emailField" type="input" selector="#email"/>
-        <element name="commentField" type="textarea" selector="#comment"/>
-        <element name="submitFormButton" type="button" selector=".action.submit.primary" timeout="30"/>
     </section>
 </sections>

--- a/app/code/Magento/Captcha/Test/Mftf/Section/StorefrontContactUsFormSection.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/Section/StorefrontContactUsFormSection.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="StorefrontContactUsFormSection">
+        <element name="captchaField" type="input" selector="#captcha_contact_us"/>
+        <element name="captchaImg" type="block" selector=".captcha-img"/>
+        <element name="captchaReload" type="block" selector=".captcha-reload"/>
+        <element name="nameField" type="input" selector="#name"/>
+        <element name="emailField" type="input" selector="#email"/>
+        <element name="commentField" type="textarea" selector="#comment"/>
+        <element name="submitFormButton" type="button" selector=".action.submit.primary" timeout="30"/>
+    </section>
+</sections>

--- a/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaOnContactUsTest.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaOnContactUsTest.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="CaptchaOnContactUsTest">
+        <annotations>
+            <features value="Captcha"/>
+            <stories value="Test creation for send comment using the contact us form with captcha."/>
+            <title value="Captcha contact us form test"/>
+            <description value="Test creation for send comment using the contact us form with captcha."/>
+            <severity value="MAJOR"/>
+            <group value="captcha"/>
+            <group value="mtf_migrated"/>
+        </annotations>
+        <before>
+            <magentoCLI command="config:set customer/captcha/forms contact_us" stepKey="enableUserEditCaptcha"/>
+            <magentoCLI command="cache:clean config full_page" stepKey="cleanInvalidatedCaches1"/>
+            <createData entity="Simple_US_Customer" stepKey="customer"/>
+        </before>
+        <after>
+            <magentoCLI command="config:set customer/captcha/forms user_login,user_forgotpassword" stepKey="revertCaptchaConfigurations"/>
+            <magentoCLI command="cache:clean config full_page" stepKey="cleanInvalidatedCaches2"/>
+            <deleteData createDataKey="customer" stepKey="deleteCustomer"/>
+        </after>
+
+        <!-- Open storefront contact us form -->
+        <amOnPage url="/contact/" stepKey="amOnContactUpPage"/>
+        <waitForPageLoad stepKey="waitForContactUpPage"/>
+
+        <!-- Check Captcha items -->
+        <waitForElementVisible selector="{{StorefrontContactUsFormSection.captchaField}}" stepKey="seeCaptchaField1"/>
+        <waitForElementVisible selector="{{StorefrontContactUsFormSection.captchaImg}}" stepKey="seeCaptchaImage1"/>
+        <waitForElementVisible selector="{{StorefrontContactUsFormSection.captchaReload}}" stepKey="seeCaptchaReloadButton1"/>
+
+        <!-- Submit Contact Us form -->
+        <fillField selector="{{StorefrontContactUsFormSection.emailField}}"  userInput="$$customer.email$$" stepKey="fillEmail"/>
+        <fillField selector="{{StorefrontContactUsFormSection.nameField}}"  userInput="$$customer.firstname$$" stepKey="fillName"/>
+        <fillField selector="{{StorefrontContactUsFormSection.commentField}}"  userInput="Lorem ipsum dolor sit amet, ne enim aliquando eam, oblique deserunt no usu." stepKey="fillComment"/>
+        <fillField selector="{{StorefrontContactUsFormSection.captchaField}}" userInput="InvalidCaptcha" stepKey="fillCaptcha" />
+        <click selector="{{StorefrontContactUsFormSection.submitFormButton}}" stepKey="clickSubmitFormButton"/>
+
+        <!-- Check Captcha items after form reload -->
+        <see userInput="Incorrect CAPTCHA" selector="{{StorefrontCustomerMessagesSection.errorMessage}}" stepKey="verifyMessage"/>
+        <waitForElementVisible selector="{{StorefrontContactUsFormSection.captchaField}}" stepKey="seeCaptchaField2"/>
+        <waitForElementVisible selector="{{StorefrontContactUsFormSection.captchaImg}}" stepKey="seeCaptchaImage2"/>
+        <waitForElementVisible selector="{{StorefrontContactUsFormSection.captchaReload}}" stepKey="seeCaptchaReloadButton2"/>
+    </test>
+</tests>

--- a/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaOnContactUsTest.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaOnContactUsTest.xml
@@ -20,35 +20,34 @@
         </annotations>
         <before>
             <magentoCLI command="config:set customer/captcha/forms contact_us" stepKey="enableUserEditCaptcha"/>
-            <magentoCLI command="cache:clean config full_page" stepKey="cleanInvalidatedCaches1"/>
-            <createData entity="Simple_US_Customer" stepKey="customer"/>
+            <magentoCLI command="cache:clean config full_page" stepKey="cleanInvalidatedCaches"/>
         </before>
         <after>
             <magentoCLI command="config:set customer/captcha/forms user_login,user_forgotpassword" stepKey="revertCaptchaConfigurations"/>
-            <magentoCLI command="cache:clean config full_page" stepKey="cleanInvalidatedCaches2"/>
-            <deleteData createDataKey="customer" stepKey="deleteCustomer"/>
+            <magentoCLI command="cache:clean config full_page" stepKey="cleanInvalidatedCaches"/>
         </after>
 
         <!-- Open storefront contact us form -->
-        <amOnPage url="/contact/" stepKey="amOnContactUpPage"/>
-        <waitForPageLoad stepKey="waitForContactUpPage"/>
+        <amOnPage url="{{StorefrontContactUsPage.url}}" stepKey="amOnContactUpPage"/>
+        <waitForPageLoad stepKey="waitForContactUpPageLoad"/>
 
         <!-- Check Captcha items -->
-        <waitForElementVisible selector="{{StorefrontContactUsFormSection.captchaField}}" stepKey="seeCaptchaField1"/>
-        <waitForElementVisible selector="{{StorefrontContactUsFormSection.captchaImg}}" stepKey="seeCaptchaImage1"/>
-        <waitForElementVisible selector="{{StorefrontContactUsFormSection.captchaReload}}" stepKey="seeCaptchaReloadButton1"/>
+        <waitForElementVisible selector="{{StorefrontContactUsCaptchaSection.captchaField}}" stepKey="seeCaptchaFieldFirst"/>
+        <waitForElementVisible selector="{{StorefrontContactUsCaptchaSection.captchaImg}}" stepKey="seeCaptchaImageFirst"/>
+        <waitForElementVisible selector="{{StorefrontContactUsCaptchaSection.captchaReload}}" stepKey="seeCaptchaReloadButtonFirst"/>
 
         <!-- Submit Contact Us form -->
-        <fillField selector="{{StorefrontContactUsFormSection.emailField}}"  userInput="$$customer.email$$" stepKey="fillEmail"/>
-        <fillField selector="{{StorefrontContactUsFormSection.nameField}}"  userInput="$$customer.firstname$$" stepKey="fillName"/>
-        <fillField selector="{{StorefrontContactUsFormSection.commentField}}"  userInput="Lorem ipsum dolor sit amet, ne enim aliquando eam, oblique deserunt no usu." stepKey="fillComment"/>
-        <fillField selector="{{StorefrontContactUsFormSection.captchaField}}" userInput="InvalidCaptcha" stepKey="fillCaptcha" />
+        <fillField selector="{{StorefrontContactUsFormSection.emailField}}"  userInput="{{Simple_US_Customer.email}}" stepKey="fillEmail"/>
+        <fillField selector="{{StorefrontContactUsFormSection.nameField}}"  userInput="{{Simple_US_Customer.firstname}}" stepKey="fillName"/>
+        <fillField selector="{{StorefrontContactUsFormSection.commentField}}"  userInput="Lorem ipsum dolor sit amet, ne enim aliquando eam, oblique deserunt no usu."
+                   stepKey="fillComment"/>
+        <fillField selector="{{StorefrontContactUsCaptchaSection.captchaField}}" userInput="InvalidCaptcha" stepKey="fillCaptcha" />
         <click selector="{{StorefrontContactUsFormSection.submitFormButton}}" stepKey="clickSubmitFormButton"/>
 
         <!-- Check Captcha items after form reload -->
         <see userInput="Incorrect CAPTCHA" selector="{{StorefrontCustomerMessagesSection.errorMessage}}" stepKey="verifyMessage"/>
-        <waitForElementVisible selector="{{StorefrontContactUsFormSection.captchaField}}" stepKey="seeCaptchaField2"/>
-        <waitForElementVisible selector="{{StorefrontContactUsFormSection.captchaImg}}" stepKey="seeCaptchaImage2"/>
-        <waitForElementVisible selector="{{StorefrontContactUsFormSection.captchaReload}}" stepKey="seeCaptchaReloadButton2"/>
+        <waitForElementVisible selector="{{StorefrontContactUsCaptchaSection.captchaField}}" stepKey="seeCaptchaFieldSecond"/>
+        <waitForElementVisible selector="{{StorefrontContactUsCaptchaSection.captchaImg}}" stepKey="seeCaptchaImageSecond"/>
+        <waitForElementVisible selector="{{StorefrontContactUsCaptchaSection.captchaReload}}" stepKey="seeCaptchaReloadButtonSecond"/>
     </test>
 </tests>

--- a/app/code/Magento/Contact/Test/Mftf/Page/StorefrontContactUsPage.xml
+++ b/app/code/Magento/Contact/Test/Mftf/Page/StorefrontContactUsPage.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/PageObject.xsd">
+    <page name="StorefrontContactUsPage" url="/contact/" area="storefront" module="Magento_Contact">
+        <section name="StorefrontContactUsFormSection"/>
+        <section name="StorefrontContactUsCaptchaSection"/>
+    </page>
+</pages>

--- a/app/code/Magento/Contact/Test/Mftf/Section/StorefrontContactUsFormSection.xml
+++ b/app/code/Magento/Contact/Test/Mftf/Section/StorefrontContactUsFormSection.xml
@@ -7,11 +7,8 @@
 -->
 
 <sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="StorefrontContactUsFormSection">
-        <element name="captchaField" type="input" selector="#captcha_contact_us"/>
-        <element name="captchaImg" type="block" selector=".captcha-img"/>
-        <element name="captchaReload" type="block" selector=".captcha-reload"/>
         <element name="nameField" type="input" selector="#name"/>
         <element name="emailField" type="input" selector="#email"/>
         <element name="commentField" type="textarea" selector="#comment"/>

--- a/dev/tests/functional/tests/app/Magento/Captcha/Test/TestCase/CaptchaOnContactUsTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Captcha/Test/TestCase/CaptchaOnContactUsTest.xml
@@ -12,6 +12,7 @@
             <data name="comment/data/captcha" xsi:type="string">111</data>
             <data name="comment/data/customer/dataset" xsi:type="string">default</data>
             <data name="configData" xsi:type="string">captcha_storefront_contact_us</data>
+            <data name="tag" xsi:type="string">mftf_migrated:yes</data>
             <constraint name="Magento\Contact\Test\Constraint\AssertContactUsSuccessMessage" />
         </variation>
     </testCase>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR with a test that checks captcha on the contact us form.

Steps:

Preconditions:
1. Enable captcha for customer.

Test Flow:
1. Open contact us page.
2. Send comment using captcha.

### Fixed Issues 
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #275 Convert CaptchaOnContactUsTest to MFTF

