### PR TITLE
Convert CaptchaOnAdminLoginTest to MFTF

### DIFF
--- a/app/code/Magento/Backend/Test/Mftf/ActionGroup/LoginAdminWithCredentialsActionGroup.xml
+++ b/app/code/Magento/Backend/Test/Mftf/ActionGroup/LoginAdminWithCredentialsActionGroup.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="LoginAdminWithCredentialsActionGroup">
+        <arguments>
+            <argument name="adminUser" type="string" />
+            <argument name="adminPassword" type="string" />
+        </arguments>
+        <amOnPage url="{{_ENV.MAGENTO_BACKEND_NAME}}" stepKey="navigateToAdmin"/>
+        <fillField selector="{{AdminLoginFormSection.username}}" userInput="{{adminUser}}" stepKey="fillUsername"/>
+        <fillField selector="{{AdminLoginFormSection.password}}" userInput="{{adminPassword}}" stepKey="fillPassword"/>
+        <click selector="{{AdminLoginFormSection.signIn}}" stepKey="clickLogin"/>
+        <closeAdminNotification stepKey="closeAdminNotification"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Backend/Test/Mftf/Section/AdminLoginFormSection.xml
+++ b/app/code/Magento/Backend/Test/Mftf/Section/AdminLoginFormSection.xml
@@ -12,5 +12,9 @@
         <element name="username" type="input" selector="#username"/>
         <element name="password" type="input" selector="#login"/>
         <element name="signIn" type="button" selector=".actions .action-primary" timeout="30"/>
+        <element name="captchaField" type="input" selector="#captcha"/>
+        <element name="captchaImg" type="block" selector="#backend_login"/>
+        <element name="captchaReload" type="block" selector="#captcha-reload"/>
+        <element name="error" type="text" selector=".message.message-error.error"/>
     </section>
 </sections>

--- a/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaOnAdminLoginTest.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaOnAdminLoginTest.xml
@@ -29,34 +29,40 @@
         <waitForPageLoad stepKey="waitForPageLoad1" />
 
         <!-- Login as Admin with incorrect credentials 3 times -->
-        <fillField selector="{{AdminLoginFormSection.username}}" userInput="adminUser" stepKey="fillUsername1"/>
-        <fillField selector="{{AdminLoginFormSection.password}}" userInput="adminPassword" stepKey="fillPassword1"/>
-        <click selector="{{AdminLoginFormSection.signIn}}" stepKey="clickLogin1"/>
-        <see userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later." selector="{{AdminLoginFormSection.error}}" stepKey="seeLoginError1"/>
+        <actionGroup ref="LoginAdminWithCredentialsActionGroup" stepKey="failedFirstLoginAdminUser">
+            <argument name="adminUser" value="adminUser" />
+            <argument name="adminPassword" value="INVALIDAdminPassword" />
+        </actionGroup>
+        <see userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later."
+             selector="{{AdminLoginFormSection.error}}" stepKey="seeFirstLoginError"/>
 
-        <fillField selector="{{AdminLoginFormSection.username}}" userInput="adminUser" stepKey="fillUsername2"/>
-        <fillField selector="{{AdminLoginFormSection.password}}" userInput="adminPassword" stepKey="fillPassword2"/>
-        <click selector="{{AdminLoginFormSection.signIn}}" stepKey="clickLogin2"/>
-        <see userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later." selector="{{AdminLoginFormSection.error}}" stepKey="seeLoginError2"/>
+        <actionGroup ref="LoginAdminWithCredentialsActionGroup" stepKey="failedSecondLoginAdminUser">
+            <argument name="adminUser" value="adminUser" />
+            <argument name="adminPassword" value="INVALIDAdminPassword" />
+        </actionGroup>
+        <see userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later."
+             selector="{{AdminLoginFormSection.error}}" stepKey="seeSecondLoginError"/>
 
-        <fillField selector="{{AdminLoginFormSection.username}}" userInput="adminUser" stepKey="fillUsername3"/>
-        <fillField selector="{{AdminLoginFormSection.password}}" userInput="adminPassword" stepKey="fillPassword3"/>
-        <click selector="{{AdminLoginFormSection.signIn}}" stepKey="clickLogin3"/>
-        <see userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later." selector="{{AdminLoginFormSection.error}}" stepKey="seeLoginError3"/>
+        <actionGroup ref="LoginAdminWithCredentialsActionGroup" stepKey="failedThirdLoginAdminUser">
+            <argument name="adminUser" value="adminUser" />
+            <argument name="adminPassword" value="INVALIDAdminPassword" />
+        </actionGroup>
+        <see userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later."
+             selector="{{AdminLoginFormSection.error}}" stepKey="seeThirdLoginError"/>
 
         <!-- Check captcha visibility on admin login page  -->
-        <waitForElementVisible selector="{{AdminLoginFormSection.captchaField}}" stepKey="seeCaptchaField1"/>
-        <waitForElementVisible selector="{{AdminLoginFormSection.captchaImg}}" stepKey="seeCaptchaImage1"/>
-        <waitForElementVisible selector="{{AdminLoginFormSection.captchaReload}}" stepKey="seeCaptchaReloadButton1"/>
+        <waitForElementVisible selector="{{AdminLoginFormSection.captchaField}}" stepKey="seeFirstCaptchaField"/>
+        <waitForElementVisible selector="{{AdminLoginFormSection.captchaImg}}" stepKey="seeFirstCaptchaImage"/>
+        <waitForElementVisible selector="{{AdminLoginFormSection.captchaReload}}" stepKey="seeFirstCaptchaReloadButton"/>
 
         <!-- Submit form with incorrect captcha -->
-        <fillField selector="{{AdminLoginFormSection.username}}" userInput="adminUser" stepKey="fillUsername4"/>
-        <fillField selector="{{AdminLoginFormSection.password}}" userInput="adminPassword" stepKey="fillPassword4"/>
-        <fillField selector="{{AdminLoginFormSection.captchaField}}" userInput="incorrectCaptcha" stepKey="fillCaptcha4"/>
-        <click selector="{{AdminLoginFormSection.signIn}}" stepKey="clickLogin4"/>
+        <fillField selector="{{AdminLoginFormSection.username}}" userInput="adminUser" stepKey="fillAdminUserNameWithCaptcha"/>
+        <fillField selector="{{AdminLoginFormSection.password}}" userInput="adminPassword" stepKey="fillPasswordWithCaptcha"/>
+        <fillField selector="{{AdminLoginFormSection.captchaField}}" userInput="incorrectCaptcha" stepKey="fillCaptcha"/>
+        <click selector="{{AdminLoginFormSection.signIn}}" stepKey="clickLoginWithCaptcha"/>
         <see userInput="Incorrect CAPTCHA." selector="{{AdminLoginFormSection.error}}" stepKey="seeCaptchaError"/>
-        <waitForElementVisible selector="{{AdminLoginFormSection.captchaField}}" stepKey="seeCaptchaField2"/>
-        <waitForElementVisible selector="{{AdminLoginFormSection.captchaImg}}" stepKey="seeCaptchaImage2"/>
-        <waitForElementVisible selector="{{AdminLoginFormSection.captchaReload}}" stepKey="seeCaptchaReloadButton2"/>
+        <waitForElementVisible selector="{{AdminLoginFormSection.captchaField}}" stepKey="seeSecondCaptchaField"/>
+        <waitForElementVisible selector="{{AdminLoginFormSection.captchaImg}}" stepKey="seeSecondCaptchaImage"/>
+        <waitForElementVisible selector="{{AdminLoginFormSection.captchaReload}}" stepKey="seeSecondCaptchaReloadButton"/>
     </test>
 </tests>

--- a/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaOnAdminLoginTest.xml
+++ b/app/code/Magento/Captcha/Test/Mftf/Test/CaptchaOnAdminLoginTest.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="CaptchaOnAdminLoginTest">
+        <annotations>
+            <features value="Captcha"/>
+            <stories value="Test creation for send comment using the contact us form with captcha."/>
+            <title value="Captcha contact us form test"/>
+            <description value="Test creation for send comment using the contact us form with captcha."/>
+            <severity value="MAJOR"/>
+            <group value="captcha"/>
+            <group value="mtf_migrated"/>
+        </annotations>
+        <before>
+
+        </before>
+        <after>
+
+        </after>
+        <!-- Open admin login page -->
+        <amOnPage url="{{AdminLoginPage.url}}" stepKey="goToAdminLoginPage" />
+        <waitForPageLoad stepKey="waitForPageLoad1" />
+
+        <!-- Login as Admin with incorrect credentials 3 times -->
+        <fillField selector="{{AdminLoginFormSection.username}}" userInput="adminUser" stepKey="fillUsername1"/>
+        <fillField selector="{{AdminLoginFormSection.password}}" userInput="adminPassword" stepKey="fillPassword1"/>
+        <click selector="{{AdminLoginFormSection.signIn}}" stepKey="clickLogin1"/>
+        <see userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later." selector="{{AdminLoginFormSection.error}}" stepKey="seeLoginError1"/>
+
+        <fillField selector="{{AdminLoginFormSection.username}}" userInput="adminUser" stepKey="fillUsername2"/>
+        <fillField selector="{{AdminLoginFormSection.password}}" userInput="adminPassword" stepKey="fillPassword2"/>
+        <click selector="{{AdminLoginFormSection.signIn}}" stepKey="clickLogin2"/>
+        <see userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later." selector="{{AdminLoginFormSection.error}}" stepKey="seeLoginError2"/>
+
+        <fillField selector="{{AdminLoginFormSection.username}}" userInput="adminUser" stepKey="fillUsername3"/>
+        <fillField selector="{{AdminLoginFormSection.password}}" userInput="adminPassword" stepKey="fillPassword3"/>
+        <click selector="{{AdminLoginFormSection.signIn}}" stepKey="clickLogin3"/>
+        <see userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later." selector="{{AdminLoginFormSection.error}}" stepKey="seeLoginError3"/>
+
+        <!-- Check captcha visibility on admin login page  -->
+        <waitForElementVisible selector="{{AdminLoginFormSection.captchaField}}" stepKey="seeCaptchaField1"/>
+        <waitForElementVisible selector="{{AdminLoginFormSection.captchaImg}}" stepKey="seeCaptchaImage1"/>
+        <waitForElementVisible selector="{{AdminLoginFormSection.captchaReload}}" stepKey="seeCaptchaReloadButton1"/>
+
+        <!-- Submit form with incorrect captcha -->
+        <fillField selector="{{AdminLoginFormSection.username}}" userInput="adminUser" stepKey="fillUsername4"/>
+        <fillField selector="{{AdminLoginFormSection.password}}" userInput="adminPassword" stepKey="fillPassword4"/>
+        <fillField selector="{{AdminLoginFormSection.captchaField}}" userInput="incorrectCaptcha" stepKey="fillCaptcha4"/>
+        <click selector="{{AdminLoginFormSection.signIn}}" stepKey="clickLogin4"/>
+        <see userInput="Incorrect CAPTCHA." selector="{{AdminLoginFormSection.error}}" stepKey="seeCaptchaError"/>
+        <waitForElementVisible selector="{{AdminLoginFormSection.captchaField}}" stepKey="seeCaptchaField2"/>
+        <waitForElementVisible selector="{{AdminLoginFormSection.captchaImg}}" stepKey="seeCaptchaImage2"/>
+        <waitForElementVisible selector="{{AdminLoginFormSection.captchaReload}}" stepKey="seeCaptchaReloadButton2"/>
+    </test>
+</tests>

--- a/dev/tests/functional/tests/app/Magento/Captcha/Test/TestCase/CaptchaOnAdminLoginTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Captcha/Test/TestCase/CaptchaOnAdminLoginTest.xml
@@ -12,6 +12,7 @@
             <data name="customAdmin/data/captcha" xsi:type="string">111</data>
             <data name="pageTitle" xsi:type="string">Dashboard</data>
             <data name="configData" xsi:type="string">captcha_backend_login</data>
+            <data name="tag" xsi:type="string">mftf_migrated:yes</data>
             <constraint name="Magento\Backend\Test\Constraint\AssertBackendPageIsAvailable" />
         </variation>
     </testCase>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR with a test that checks captcha and lockout customer on the admin login page.
Steps:

Test Flow:
1. Open admin login page.
2. Try to login with incorrect password 3 or more times.
3.  Check captcha visibility after incorrect password submit the form 
4. Submit the form with incorrect captcha.

### Fixed Issues 
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #247  Convert CaptchaOnAdminLoginTest to MFTF

