### PR TITLE
Convert AccessAdminWithStoreCodeInUrlTest to MFTF

### DIFF
--- a/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminAssertDashboardPageIsVisibleActionGroup.xml
+++ b/app/code/Magento/Backend/Test/Mftf/ActionGroup/AdminAssertDashboardPageIsVisibleActionGroup.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminAssertDashboardPageIsVisibleActionGroup">
+        <seeInCurrentUrl url="{{AdminDashboardPage.url}}" stepKey="seeDashboardUrl"/>
+        <see userInput="Dashboard" selector="{{AdminHeaderSection.pageTitle}}" stepKey="seeDashboardTitle"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Backend/Test/Mftf/Data/BackendConfigData.xml
+++ b/app/code/Magento/Backend/Test/Mftf/Data/BackendConfigData.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<entities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:DataGenerator/etc/dataProfileSchema.xsd">
+    <entity name="StorefrontDisableAddStoreCodeToUrls">
+        <!-- Magento default value -->
+        <data key="path">web/url/use_store</data>
+        <data key="scope_id">0</data>
+        <data key="label">No</data>
+        <data key="value">0</data>
+    </entity>
+    <entity name="StorefrontEnableAddStoreCodeToUrls">
+        <data key="path">web/url/use_store</data>
+        <data key="scope_id">0</data>
+        <data key="label">Yes</data>
+        <data key="value">1</data>
+    </entity>
+</entities>

--- a/app/code/Magento/Backend/Test/Mftf/Test/AdminUserLoginWithStoreCodeInUrlTest.xml
+++ b/app/code/Magento/Backend/Test/Mftf/Test/AdminUserLoginWithStoreCodeInUrlTest.xml
@@ -17,13 +17,13 @@
             <group value="mtf_migrated"/>
         </annotations>
         <before>
-            <magentoCLI command="config:set web/url/use_store 1" stepKey="addStoreCodeToUrl"/>
+            <magentoCLI command="config:set {{StorefrontEnableAddStoreCodeToUrls.path}} {{StorefrontEnableAddStoreCodeToUrls.value}}" stepKey="addStoreCodeToUrlEnable"/>
         </before>
         <after>
-            <magentoCLI command="config:set web/url/use_store 0" stepKey="addStoreCodeToUrlDisable"/>
+            <magentoCLI command="config:set {{StorefrontDisableAddStoreCodeToUrls.path}} {{StorefrontDisableAddStoreCodeToUrls.value}}" stepKey="addStoreCodeToUrlDisable"/>
         </after>
 
         <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
-        <see userInput="Dashboard" selector="{{AdminHeaderSection.pageTitle}}" stepKey="seeDashboardTitle"/>
+        <actionGroup ref="AdminAssertDashboardPageIsVisibleActionGroup" stepKey="seeDashboardPage"/>
     </test>
 </tests>

--- a/app/code/Magento/Backend/Test/Mftf/Test/AdminUserLoginWithStoreCodeInUrlTest.xml
+++ b/app/code/Magento/Backend/Test/Mftf/Test/AdminUserLoginWithStoreCodeInUrlTest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminUserLoginWithStoreCodeInUrlTest">
+        <annotations>
+            <features value="Backend"/>
+            <title value="Admin panel should be accessible with Add Store Code to URL setting enabled"/>
+            <description value="Admin panel should be accessible with Add Store Code to URL setting enabled"/>
+            <group value="backend"/>
+            <group value="mtf_migrated"/>
+        </annotations>
+        <before>
+            <magentoCLI command="config:set web/url/use_store 1" stepKey="addStoreCodeToUrl"/>
+        </before>
+        <after>
+            <magentoCLI command="config:set web/url/use_store 0" stepKey="addStoreCodeToUrlDisable"/>
+        </after>
+
+        <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+        <see userInput="Dashboard" selector="{{AdminHeaderSection.pageTitle}}" stepKey="seeDashboardTitle"/>
+    </test>
+</tests>

--- a/app/code/Magento/Store/Test/Mftf/ActionGroup/StorefrontAssertStoreCodeInUrlActionGroup.xml
+++ b/app/code/Magento/Store/Test/Mftf/ActionGroup/StorefrontAssertStoreCodeInUrlActionGroup.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontAssertStoreCodeInUrlActionGroup">
+        <seeInCurrentUrl url="{{StorefrontHomePage.url}}{{_defaultStore.code}}" stepKey="seeStoreCodeInURL"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Store/Test/Mftf/Test/StorefrontAddStoreCodeInUrlTest.xml
+++ b/app/code/Magento/Store/Test/Mftf/Test/StorefrontAddStoreCodeInUrlTest.xml
@@ -17,16 +17,13 @@
             <group value="mtf_migrated"/>
         </annotations>
         <before>
-            <magentoCLI command="config:set web/url/use_store 1" stepKey="addStoreCodeToUrl"/>
+            <magentoCLI command="config:set {{StorefrontEnableAddStoreCodeToUrls.path}} {{StorefrontEnableAddStoreCodeToUrls.value}}" stepKey="addStoreCodeToUrlEnable"/>
         </before>
         <after>
-            <magentoCLI command="config:set web/url/use_store 0" stepKey="addStoreCodeToUrlDisable"/>
+            <magentoCLI command="config:set {{StorefrontDisableAddStoreCodeToUrls.path}} {{StorefrontDisableAddStoreCodeToUrls.value}}" stepKey="addStoreCodeToUrlDisable"/>
         </after>
 
-        <amOnPage url="{{StorefrontHomePage.url}}" stepKey="gotToHomePage"/>
-        <waitForPageLoad stepKey="waitForHomePageLoaded1"/>
-        <click selector="{{StorefrontHeaderSection.logoLink}}" stepKey="clickOnLogo"/>
-        <waitForPageLoad stepKey="waitForHomePageLoaded2"/>
-        <seeInCurrentUrl url="{{StorefrontHomePage.url}}{{_defaultStore.code}}" stepKey="seeStoreCodeInURL"/>
+        <actionGroup ref="StorefrontClickOnHeaderLogoActionGroup" stepKey="clickOnStorefrontHeaderLogo"/>
+        <actionGroup ref="StorefrontAssertStoreCodeInUrlActionGroup" stepKey="seeStoreCodeInUrl"/>
     </test>
 </tests>

--- a/app/code/Magento/Store/Test/Mftf/Test/StorefrontAddStoreCodeInUrlTest.xml
+++ b/app/code/Magento/Store/Test/Mftf/Test/StorefrontAddStoreCodeInUrlTest.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="StorefrontAddStoreCodeInUrlTest">
+        <annotations>
+            <features value="Backend"/>
+            <title value="Store code should be added to storefront URL if the corresponding configuration is enabled"/>
+            <description value="Store code should be added to storefront URL if the corresponding configuration is enabled"/>
+            <group value="store"/>
+            <group value="mtf_migrated"/>
+        </annotations>
+        <before>
+            <magentoCLI command="config:set web/url/use_store 1" stepKey="addStoreCodeToUrl"/>
+        </before>
+        <after>
+            <magentoCLI command="config:set web/url/use_store 0" stepKey="addStoreCodeToUrlDisable"/>
+        </after>
+
+        <amOnPage url="{{StorefrontHomePage.url}}" stepKey="gotToHomePage"/>
+        <waitForPageLoad stepKey="waitForHomePageLoaded1"/>
+        <click selector="{{StorefrontHeaderSection.logoLink}}" stepKey="clickOnLogo"/>
+        <waitForPageLoad stepKey="waitForHomePageLoaded2"/>
+        <seeInCurrentUrl url="{{StorefrontHomePage.url}}{{_defaultStore.code}}" stepKey="seeStoreCodeInURL"/>
+    </test>
+</tests>

--- a/app/code/Magento/Theme/Test/Mftf/ActionGroup/StorefrontClickOnHeaderLogoActionGroup.xml
+++ b/app/code/Magento/Theme/Test/Mftf/ActionGroup/StorefrontClickOnHeaderLogoActionGroup.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="StorefrontClickOnHeaderLogoActionGroup">
+        <amOnPage url="{{StorefrontHomePage.url}}" stepKey="gotToHomePage"/>
+        <waitForPageLoad stepKey="waitForHomePageLoaded1"/>
+        <click selector="{{StorefrontHeaderSection.logoLink}}" stepKey="clickOnLogo"/>
+        <waitForPageLoad stepKey="waitForHomePageLoaded2"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Theme/Test/Mftf/Section/StorefrontHeaderSection.xml
+++ b/app/code/Magento/Theme/Test/Mftf/Section/StorefrontHeaderSection.xml
@@ -9,5 +9,6 @@
           xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
     <section name="StorefrontHeaderSection">
         <element name="welcomeMessage" type="text" selector=".greet.welcome"/>
+        <element name="logoLink" type="button" selector=".header .logo"/>
     </section>
 </sections>

--- a/dev/tests/functional/tests/app/Magento/Store/Test/TestCase/AccessAdminWithStoreCodeInUrlTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Store/Test/TestCase/AccessAdminWithStoreCodeInUrlTest.xml
@@ -11,6 +11,7 @@
             <data name="configData" xsi:type="string">add_store_code_to_urls</data>
             <data name="user/dataset" xsi:type="string">default</data>
             <data name="storeCode" xsi:type="string">default</data>
+            <data name="tag" xsi:type="string">mftf_migrated:yes</data>
             <constraint name="Magento\User\Test\Constraint\AssertUserSuccessLogin" />
             <constraint name="Magento\Store\Test\Constraint\AssertStoreCodeInUrl" />
         </variation>


### PR DESCRIPTION
### Description (*)
This PR introduces test coverage for the following cases.

Case #1
- Enable "Add store code to URL" option
- Admin should be able to log in

Case #2 
- Enable "Add store code to URL" option
- URL should contain store code on the storefront

### Fixed Issues (if relevant)
1. #323: Convert AccessAdminWithStoreCodeInUrlTest to MFTF
