### PR TITLE
Convert LockAdminUserWhenCreatingNewUserTest to MFTF

### DIFF
--- a/app/code/Magento/Backend/Test/Mftf/Page/AdminAddNewUserPage.xml
+++ b/app/code/Magento/Backend/Test/Mftf/Page/AdminAddNewUserPage.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<pages xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/PageObject.xsd">
+    <page name="AdminAddNewUserPage" url="admin/user/new" area="admin" module="Backend">
+        <section name="AddNewAdminUserSection"/>
+    </page>
+</pages>

--- a/app/code/Magento/Backend/Test/Mftf/Section/AdminLoginFormSection.xml
+++ b/app/code/Magento/Backend/Test/Mftf/Section/AdminLoginFormSection.xml
@@ -12,5 +12,6 @@
         <element name="username" type="input" selector="#username"/>
         <element name="password" type="input" selector="#login"/>
         <element name="signIn" type="button" selector=".actions .action-primary" timeout="30"/>
+        <element name="error" type="text" selector=".message.message-error.error"/>
     </section>
 </sections>

--- a/app/code/Magento/Backend/Test/Mftf/Section/AdminNewUserSection.xml
+++ b/app/code/Magento/Backend/Test/Mftf/Section/AdminNewUserSection.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<sections xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:Page/etc/SectionObject.xsd">
+    <section name="AdminNewUserSection">
+        <element name="username" type="input" selector="#user_username"/>
+        <element name="firstname" type="input" selector="#user_firstname"/>
+        <element name="lastname" type="input" selector="#user_lastname"/>
+        <element name="email" type="input" selector="#user_email"/>
+        <element name="password" type="input" selector="#user_password"/>
+        <element name="confirmation" type="input" selector="#user_confirmation"/>
+        <element name="currentPassword" type="input" selector="#user_current_password"/>
+        <element name="save" type="button" selector="#save"/>
+        <element name="userRoleTab" type="button" selector="#page_tabs_roles_section"/>
+        <element name="administratorRole" type="radio" selector="//*[@id='permissionsUserRolesGrid_table']//td[{{role}}]/input" parameterized="true"/>
+    </section>
+</sections>

--- a/app/code/Magento/Security/Test/Mftf/ActionGroup/AdminNewUserInvalidCurrentUserPasswordActionGroup.xml
+++ b/app/code/Magento/Security/Test/Mftf/ActionGroup/AdminNewUserInvalidCurrentUserPasswordActionGroup.xml
@@ -8,17 +8,27 @@
 <actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
     <actionGroup name="AdminNewUserInvalidCurrentUserPasswordActionGroup">
+        <arguments>
+            <argument name="adminUser" type="string" />
+            <argument name="adminFirstname" type="string" />
+            <argument name="adminLastname" type="string" />
+            <argument name="adminEmail" type="string" />
+            <argument name="adminPassword" type="string" />
+            <argument name="adminPasswordConfirmation" type="string" />
+            <argument name="currentAdminPassword" type="string" />
+            <argument name="adminUserRole" type="string"/>
+        </arguments>
         <!-- Fill in all data according to data set (current password is incorrect). -->
-        <fillField selector="{{AdminNewUserSection.username}}" userInput="{{AdminUserData.username}}" stepKey="fillUser"/>
-        <fillField selector="{{AdminNewUserSection.firstname}}" userInput="{{AdminUserData.firstname}}" stepKey="fillFirstName"/>
-        <fillField selector="{{AdminNewUserSection.lastname}}" userInput="{{AdminUserData.lastname}}" stepKey="fillLastName"/>
-        <fillField selector="{{AdminNewUserSection.email}}" userInput="{{AdminUserData.email}}" stepKey="fillEmail"/>
-        <fillField selector="{{AdminNewUserSection.password}}" userInput="{{AdminUserData.password}}" stepKey="fillPassword"/>
-        <fillField selector="{{AdminNewUserSection.confirmation}}" userInput="{{AdminUserData.password}}" stepKey="fillPasswordConfirmation"/>
-        <fillField selector="{{AdminNewUserSection.currentPassword}}" userInput="{{AdminUserData.password}}INVALID" stepKey="fillCurrentUserPassword"/>
+        <fillField selector="{{AdminNewUserSection.username}}" userInput="{{adminUser}}" stepKey="fillUser"/>
+        <fillField selector="{{AdminNewUserSection.firstname}}" userInput="{{adminFirstname}}" stepKey="fillFirstName"/>
+        <fillField selector="{{AdminNewUserSection.lastname}}" userInput="{{adminLastname}}" stepKey="fillLastName"/>
+        <fillField selector="{{AdminNewUserSection.email}}" userInput="{{adminEmail}}" stepKey="fillEmail"/>
+        <fillField selector="{{AdminNewUserSection.password}}" userInput="{{adminPassword}}" stepKey="fillPassword"/>
+        <fillField selector="{{AdminNewUserSection.confirmation}}" userInput="{{adminPasswordConfirmation}}" stepKey="fillPasswordConfirmation"/>
+        <fillField selector="{{AdminNewUserSection.currentPassword}}" userInput="{{currentAdminPassword}}" stepKey="fillCurrentUserPassword"/>
         <scrollToTopOfPage stepKey="ScrollToTopOfPage"/>
         <click selector="{{AdminNewUserSection.userRoleTab}}" stepKey="openUserRoleTab"/>
-        <click selector="{{AdminNewUserSection.administratorRole('1')}}" stepKey="assignRole"/>
+        <click selector="{{adminUserRole}}" stepKey="assignRole"/>
         <click selector="{{AdminNewUserSection.save}}" stepKey="saveNewUser"/>
         <waitForPageLoad stepKey="waitForSaveResultLoad"/>
     </actionGroup>

--- a/app/code/Magento/Security/Test/Mftf/ActionGroup/AdminNewUserInvalidCurrentUserPasswordActionGroup.xml
+++ b/app/code/Magento/Security/Test/Mftf/ActionGroup/AdminNewUserInvalidCurrentUserPasswordActionGroup.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<actionGroups xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/actionGroupSchema.xsd">
+    <actionGroup name="AdminNewUserInvalidCurrentUserPasswordActionGroup">
+        <!-- Fill in all data according to data set (current password is incorrect). -->
+        <fillField selector="{{AdminNewUserSection.username}}" userInput="{{AdminUserData.username}}" stepKey="fillUser"/>
+        <fillField selector="{{AdminNewUserSection.firstname}}" userInput="{{AdminUserData.firstname}}" stepKey="fillFirstName"/>
+        <fillField selector="{{AdminNewUserSection.lastname}}" userInput="{{AdminUserData.lastname}}" stepKey="fillLastName"/>
+        <fillField selector="{{AdminNewUserSection.email}}" userInput="{{AdminUserData.email}}" stepKey="fillEmail"/>
+        <fillField selector="{{AdminNewUserSection.password}}" userInput="{{AdminUserData.password}}" stepKey="fillPassword"/>
+        <fillField selector="{{AdminNewUserSection.confirmation}}" userInput="{{AdminUserData.password}}" stepKey="fillPasswordConfirmation"/>
+        <fillField selector="{{AdminNewUserSection.currentPassword}}" userInput="{{AdminUserData.password}}INVALID" stepKey="fillCurrentUserPassword"/>
+        <scrollToTopOfPage stepKey="ScrollToTopOfPage"/>
+        <click selector="{{AdminNewUserSection.userRoleTab}}" stepKey="openUserRoleTab"/>
+        <click selector="{{AdminNewUserSection.administratorRole('1')}}" stepKey="assignRole"/>
+        <click selector="{{AdminNewUserSection.save}}" stepKey="saveNewUser"/>
+        <waitForPageLoad stepKey="waitForSaveResultLoad"/>
+    </actionGroup>
+</actionGroups>

--- a/app/code/Magento/Security/Test/Mftf/Data/AdminUserData.xml
+++ b/app/code/Magento/Security/Test/Mftf/Data/AdminUserData.xml
@@ -11,7 +11,7 @@
     <entity name="AdminUserData" type="admin">
         <data key="email" unique="prefix">John.Doe@example.com</data>
         <data key="firstname">John</data>
-        <data key="username">lockuser</data>
+        <data key="username" unique="prefix">lockuser</data>
         <data key="lastname">Doe</data>
         <data key="password">pwdTest123!</data>
     </entity>

--- a/app/code/Magento/Security/Test/Mftf/Data/AdminUserData.xml
+++ b/app/code/Magento/Security/Test/Mftf/Data/AdminUserData.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<entities xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="urn:magento:mftf:DataGenerator/etc/dataProfileSchema.xsd">
+    <entity name="AdminUserData" type="admin">
+        <data key="email" unique="prefix">John.Doe@example.com</data>
+        <data key="firstname">John</data>
+        <data key="username">lockuser</data>
+        <data key="lastname">Doe</data>
+        <data key="password">pwdTest123!</data>
+    </entity>
+</entities>

--- a/app/code/Magento/Security/Test/Mftf/Test/LockAdminUserWhenCreatingNewUserTest.xml
+++ b/app/code/Magento/Security/Test/Mftf/Test/LockAdminUserWhenCreatingNewUserTest.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="LockAdminUserWhenCreatingNewUserTest">
+        <annotations>
+            <features value="Security"/>
+            <stories value="Runs Lock admin user when creating new user test."/>
+            <title value="Lock admin user when creating new user"/>
+            <description value="Runs Lock admin user when creating new user test."/>
+            <severity value="MAJOR"/>
+            <group value="security"/>
+            <group value="mtf_migrated"/>
+        </annotations>
+        <before>
+            <!-- Log in to Admin Panel -->
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <!-- Unlock Admin user -->
+            <magentoCLI command="admin:user:unlock {{_ENV.MAGENTO_ADMIN_USERNAME}}" stepKey="unlockAdminUser"/>
+        </after>
+
+        <!-- Open Admin New User Page -->
+        <amOnPage url="{{AdminAddNewUserPage.url}}" stepKey="amOnNewAdminUserPage"/>
+        <waitForPageLoad stepKey="waitForNewAdminUserPageLoad"/>
+
+        <!-- Perform add new admin user 6 specified number of times.
+        "The password entered for the current user is invalid. Verify the password and try again." appears after each attempt.-->
+        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserAttempt1">
+        </actionGroup>
+        <waitForPageLoad stepKey="waitForSaveResultLoad"/>
+        <see selector="{{AdminMessagesSection.error}}" userInput="The password entered for the current user is invalid. Verify the password and try again."
+             stepKey="seeInvalidPasswordError"/>
+        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserAttempt2">
+        </actionGroup>
+        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserAttempt3">
+        </actionGroup>
+        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserAttempt4">
+        </actionGroup>
+        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserAttempt5">
+        </actionGroup>
+        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserAttempt6">
+        </actionGroup>
+
+        <!-- Check Error that account has been locked -->
+        <waitForPageLoad stepKey="wailtForSaveResultLoad"/>
+        <see selector="{{AdminLoginFormSection.error}}" userInput="Your account is temporarily disabled. Please try again later." stepKey="seeLockUserError"/>
+
+        <!-- Try to login as admin and check error -->
+        <actionGroup ref="LoginAsAdmin" stepKey="loginAsLockedAdmin"/>
+        <waitForPageLoad stepKey="waitForError"/>
+        <see selector="{{AdminLoginFormSection.error}}" userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later"
+             stepKey="seeLockUserError2"/>
+    </test>
+</tests>

--- a/app/code/Magento/Security/Test/Mftf/Test/LockAdminUserWhenCreatingNewUserTest.xml
+++ b/app/code/Magento/Security/Test/Mftf/Test/LockAdminUserWhenCreatingNewUserTest.xml
@@ -33,20 +33,68 @@
 
         <!-- Perform add new admin user 6 specified number of times.
         "The password entered for the current user is invalid. Verify the password and try again." appears after each attempt.-->
-        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserAttempt1">
+        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserFirstAttempt">
+            <argument name="adminUser" value="{{AdminUserData.username}}" />
+            <argument name="adminFirstname" value="{{AdminUserData.firstname}}" />
+            <argument name="adminLastname" value="{{AdminUserData.lastname}}" />
+            <argument name="adminEmail" value="{{AdminUserData.email}}" />
+            <argument name="adminPassword" value="{{AdminUserData.password}}" />
+            <argument name="adminPasswordConfirmation" value="{{AdminUserData.password}}" />
+            <argument name="currentAdminPassword" value="{{AdminUserData.password}}INVALID" />
+            <argument name="adminUserRole" value="{{AdminNewUserSection.administratorRole('1')}}" />
         </actionGroup>
         <waitForPageLoad stepKey="waitForSaveResultLoad"/>
         <see selector="{{AdminMessagesSection.error}}" userInput="The password entered for the current user is invalid. Verify the password and try again."
              stepKey="seeInvalidPasswordError"/>
-        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserAttempt2">
+        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserSecondAttempt">
+            <argument name="adminUser" value="{{AdminUserData.username}}" />
+            <argument name="adminFirstname" value="{{AdminUserData.firstname}}" />
+            <argument name="adminLastname" value="{{AdminUserData.lastname}}" />
+            <argument name="adminEmail" value="{{AdminUserData.email}}" />
+            <argument name="adminPassword" value="{{AdminUserData.password}}" />
+            <argument name="adminPasswordConfirmation" value="{{AdminUserData.password}}" />
+            <argument name="currentAdminPassword" value="{{AdminUserData.password}}INVALID" />
+            <argument name="adminUserRole" value="{{AdminNewUserSection.administratorRole('1')}}" />
         </actionGroup>
-        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserAttempt3">
+        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserThirdAttempt">
+            <argument name="adminUser" value="{{AdminUserData.username}}" />
+            <argument name="adminFirstname" value="{{AdminUserData.firstname}}" />
+            <argument name="adminLastname" value="{{AdminUserData.lastname}}" />
+            <argument name="adminEmail" value="{{AdminUserData.email}}" />
+            <argument name="adminPassword" value="{{AdminUserData.password}}" />
+            <argument name="adminPasswordConfirmation" value="{{AdminUserData.password}}" />
+            <argument name="currentAdminPassword" value="{{AdminUserData.password}}INVALID" />
+            <argument name="adminUserRole" value="{{AdminNewUserSection.administratorRole('1')}}" />
         </actionGroup>
-        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserAttempt4">
+        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserFourthAttempt">
+            <argument name="adminUser" value="{{AdminUserData.username}}" />
+            <argument name="adminFirstname" value="{{AdminUserData.firstname}}" />
+            <argument name="adminLastname" value="{{AdminUserData.lastname}}" />
+            <argument name="adminEmail" value="{{AdminUserData.email}}" />
+            <argument name="adminPassword" value="{{AdminUserData.password}}" />
+            <argument name="adminPasswordConfirmation" value="{{AdminUserData.password}}" />
+            <argument name="currentAdminPassword" value="{{AdminUserData.password}}INVALID" />
+            <argument name="adminUserRole" value="{{AdminNewUserSection.administratorRole('1')}}" />
         </actionGroup>
-        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserAttempt5">
+        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserFifthAttempt">
+            <argument name="adminUser" value="{{AdminUserData.username}}" />
+            <argument name="adminFirstname" value="{{AdminUserData.firstname}}" />
+            <argument name="adminLastname" value="{{AdminUserData.lastname}}" />
+            <argument name="adminEmail" value="{{AdminUserData.email}}" />
+            <argument name="adminPassword" value="{{AdminUserData.password}}" />
+            <argument name="adminPasswordConfirmation" value="{{AdminUserData.password}}" />
+            <argument name="currentAdminPassword" value="{{AdminUserData.password}}INVALID" />
+            <argument name="adminUserRole" value="{{AdminNewUserSection.administratorRole('1')}}" />
         </actionGroup>
-        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserAttempt6">
+        <actionGroup ref="AdminNewUserInvalidCurrentUserPasswordActionGroup" stepKey="failedSaveUserSixthAttempt">
+            <argument name="adminUser" value="{{AdminUserData.username}}" />
+            <argument name="adminFirstname" value="{{AdminUserData.firstname}}" />
+            <argument name="adminLastname" value="{{AdminUserData.lastname}}" />
+            <argument name="adminEmail" value="{{AdminUserData.email}}" />
+            <argument name="adminPassword" value="{{AdminUserData.password}}" />
+            <argument name="adminPasswordConfirmation" value="{{AdminUserData.password}}" />
+            <argument name="currentAdminPassword" value="{{AdminUserData.password}}INVALID" />
+            <argument name="adminUserRole" value="{{AdminNewUserSection.administratorRole('1')}}" />
         </actionGroup>
 
         <!-- Check Error that account has been locked -->
@@ -57,6 +105,6 @@
         <actionGroup ref="LoginAsAdmin" stepKey="loginAsLockedAdmin"/>
         <waitForPageLoad stepKey="waitForError"/>
         <see selector="{{AdminLoginFormSection.error}}" userInput="The account sign-in was incorrect or your account is disabled temporarily. Please wait and try again later"
-             stepKey="seeLockUserError2"/>
+             stepKey="seeLoginUserError"/>
     </test>
 </tests>

--- a/dev/tests/functional/tests/app/Magento/Security/Test/TestCase/LockAdminUserWhenCreatingNewUserTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Security/Test/TestCase/LockAdminUserWhenCreatingNewUserTest.xml
@@ -19,6 +19,7 @@
             <data name="user/data/password_confirmation" xsi:type="string">123123q</data>
             <data name="user/data/current_password" xsi:type="string">incorrect password</data>
             <data name="attempts" xsi:type="string">4</data>
+            <data name="tag" xsi:type="string">mftf_migrated:yes</data>
             <constraint name="Magento\Security\Test\Constraint\AssertUserIsLocked" />
         </variation>
     </testCase>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
This PR with a test that checks lock admin user when creating a new user
Steps:

Steps:
1. Log in to backend as admin user.
2. Navigate to New User Page.
3. Fill in all data according to data set (password is incorrect).
4. Perform action 6 specified number of times.
5. "The password entered for the current user is invalid. Verify the password and try again." appears after each attempt.
6. Check If the user was locked
### Fixed Issues 
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. #382 - Convert LockAdminUserWhenCreatingNewUserTest to MFTF

