### PR TITLE
Convert UpdateCmsPageEntityTest to MFTF

### DIFF
--- a/app/code/Magento/Cms/Test/Mftf/Section/CmsNewPagePageBasicFieldsSection.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Section/CmsNewPagePageBasicFieldsSection.xml
@@ -12,6 +12,7 @@
         <element name="pageTitle" type="input" selector="input[name=title]"/>
         <element name="RequiredFieldIndicator" type="text" selector=" return window.getComputedStyle(document.querySelector('._required[data-index=title]&gt;.admin__field-label span'), ':after').getPropertyValue('content');"/>
         <element name="isActive" type="button" selector="//input[@name='is_active' and @value='{{var1}}']" parameterized="true"/>
+        <element name="isActiveLabel" type="button" selector="div[data-index=is_active] .admin__actions-switch-label"/>
         <element name="duplicatedURLKey" type="input" selector="//input[contains(@data-value,'{{var1}}')]" parameterized="true"/>
     </section>
 </sections>

--- a/app/code/Magento/Cms/Test/Mftf/Test/AdminUpdateCmsPageEntityTest.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Test/AdminUpdateCmsPageEntityTest.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  *CreateNewPage Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminUpdateCmsPageEntityTest">
+        <annotations>
+            <features value="Cms"/>
+            <title value="Update CMS Page via the Admin"/>
+            <description value="Admin should be able to update a CMS Page"/>
+            <group value="backend"/>
+            <group value="cMSContent"/>
+            <group value="mtf_migrated"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+            <createData entity="_defaultCmsPage" stepKey="createCMSPage" />
+        </before>
+        <after>
+            <deleteData createDataKey="createCMSPage" stepKey="deleteCMSPage" />
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+        <!--Update page, deactivate-->
+        <!--Navigate to Page in Admin-->
+        <actionGroup ref="navigateToCreatedCMSPage" stepKey="navigateToCreatedCMSPage">
+            <argument name="CMSPage" value="$$createCMSPage$$"/>
+        </actionGroup>
+        <!--Fill data using _duplicatedCMSPage-->
+        <actionGroup ref="FillOutCMSPageContent" stepKey="fillNewData"/>
+        <!--Deactivate page-->
+        <seeElement selector="{{CmsNewPagePageBasicFieldsSection.isActive('1')}}" stepKey="seePageIsEnabled" />
+        <click selector="{{CmsNewPagePageBasicFieldsSection.isActiveLabel}}" stepKey="setPageNotActive"/>
+        <!--Save page-->
+        <actionGroup ref="saveCmsPage" stepKey="saveDeactivatedPage"/>
+        <!--Check that page is not found on frontend-->
+        <amOnPage url="{{StorefrontHomePage.url}}/{{_duplicatedCMSPage.identifier}}" stepKey="amOnDeactivatedPageOnFrontend"/>
+        <waitForPageLoad stepKey="waitForDeactivatedPageLoadOnFrontend"/>
+        <see userInput="Whoops, our bad..." stepKey="seePageError"/>
+        <!--Check page data is updated properly-->
+        <!--Navigate to Page in Admin-->
+        <actionGroup ref="navigateToCreatedCMSPage" stepKey="navigateToUpdatedCMSPageInAdmin">
+            <argument name="CMSPage" value="_duplicatedCMSPage"/>
+        </actionGroup>
+        <!--Verify data in admin-->
+        <actionGroup ref="AssertCMSPageContent" stepKey="verifyPageDataInAdmin"/>
+        <!--Activate page-->
+        <seeElement selector="{{CmsNewPagePageBasicFieldsSection.isActive('0')}}" stepKey="seePageIsDisabled" />
+        <click selector="{{CmsNewPagePageBasicFieldsSection.isActiveLabel}}" stepKey="setPageActive"/>
+        <actionGroup ref="saveCmsPage" stepKey="saveActivatedPage"/>
+        <!--Flush cache-->
+        <magentoCLI command="cache:flush" stepKey="flushCache"/>
+        <!--Verify data on frontend-->
+        <amOnPage url="{{StorefrontHomePage.url}}/{{_duplicatedCMSPage.identifier}}" stepKey="amOnPageTestPage"/>
+        <actionGroup ref="AssertStoreFrontCMSPage" stepKey="verifyPageDataOnFrontend">
+            <argument name="cmsTitle" value="{{_duplicatedCMSPage.title}}"/>
+            <argument name="cmsContent" value="{{_duplicatedCMSPage.content}}"/>
+            <argument name="cmsContentHeading" value="{{_duplicatedCMSPage.content_heading}}"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/dev/tests/functional/tests/app/Magento/Cms/Test/TestCase/UpdateCmsPageEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/Cms/Test/TestCase/UpdateCmsPageEntityTest.xml
@@ -12,6 +12,7 @@
             <data name="cms/data/title" xsi:type="string">CmsPageEdited%isolation%</data>
             <data name="cms/data/is_active" xsi:type="string">No</data>
             <data name="cms/data/content/content" xsi:type="string">cms_page_text_content_after_edit</data>
+            <data name="tag" xsi:type="string">mftf_migrated:yes</data>
             <constraint name="Magento\Cms\Test\Constraint\AssertCmsPageSuccessSaveMessage" />
             <constraint name="Magento\Cms\Test\Constraint\AssertCmsPageDisabledOnFrontend" />
         </variation>
@@ -21,6 +22,7 @@
             <data name="cms/data/identifier" xsi:type="string">cms_page_url_edited_%isolation%</data>
             <data name="cms/data/content_heading" xsi:type="string">Content Heading TextEdited</data>
             <data name="cms/data/content/content" xsi:type="string">cms_page_text_content_after_edit</data>
+            <data name="tag" xsi:type="string">mftf_migrated:yes</data>
             <constraint name="Magento\Cms\Test\Constraint\AssertCmsPageSuccessSaveMessage" />
             <constraint name="Magento\Cms\Test\Constraint\AssertCmsPageForm" />
             <constraint name="Magento\Cms\Test\Constraint\AssertCmsPagePreview" />


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR introduces functional test coverage for CMS page update feature.

Steps:
- Admin updates and deactivates page
- Check if page in disabled on frontend
- Check if page data has been updated in Admin
- Enable page
- Check if page data has been updated on frontend

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento-functional-tests-migration#630: Convert UpdateCmsPageEntityTest to MFTF
