### PR TITLE
#631 Convert CreateCmsPageEntityTest to MFTF

### DIFF
--- a/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertCMSPageContentActionGroup.xml
+++ b/app/code/Magento/Cms/Test/Mftf/ActionGroup/AssertCMSPageContentActionGroup.xml
@@ -23,6 +23,18 @@
         <executeJS function="(el = document.querySelector('[name=\'identifier\']')) &amp;&amp; el['se' + 'tAt' + 'tribute']('data-value', el.value.split('-')[0]);" stepKey="setAttribute" />
         <seeElement selector="{{CmsNewPagePageBasicFieldsSection.duplicatedURLKey(_duplicatedCMSPage.title)}}" stepKey="see"/>
     </actionGroup>
+    <actionGroup name="AssertCMSPageStoreId">
+        <arguments>
+            <argument name="storeId" type="string"/>
+        </arguments>
+        <click selector="{{CmsNewPagePiwSection.header}}" stepKey="clickPageInWebsites"/>
+        <waitForElementVisible selector="{{CmsNewPagePiwSection.storeIdDropdown}}" stepKey="waitForStoresSectionReload"/>
+        <grabValueFrom selector="{{CmsNewPagePiwSection.storeIdDropdown}}"  stepKey="grabValueFromStoreView"/>
+        <assertEquals stepKey="assertTitle" message="pass">
+            <expectedResult type="string">{{storeId}}</expectedResult>
+            <actualResult type="variable">grabValueFromStoreView</actualResult>
+        </assertEquals>
+    </actionGroup>
     <actionGroup name="AssertStoreFrontCMSPage">
         <arguments>
             <argument name="cmsTitle" type="string"/>

--- a/app/code/Magento/Cms/Test/Mftf/ActionGroup/FillOutCMSPageContentActionGroup.xml
+++ b/app/code/Magento/Cms/Test/Mftf/ActionGroup/FillOutCMSPageContentActionGroup.xml
@@ -11,7 +11,24 @@
         <fillField selector="{{CmsNewPagePageBasicFieldsSection.pageTitle}}" userInput="{{_duplicatedCMSPage.title}}" stepKey="fillFieldTitle"/>
         <click selector="{{CmsNewPagePageContentSection.header}}" stepKey="clickExpandContentTabForPage"/>
         <fillField selector="{{CmsNewPagePageContentSection.content}}" userInput="{{_duplicatedCMSPage.content}}" stepKey="fillFieldContent"/>
+        <fillField selector="{{CmsNewPagePageContentSection.contentHeading}}" userInput="{{_duplicatedCMSPage.content_heading}}" stepKey="fillFieldContentHeading"/>
         <click selector="{{CmsNewPagePageSeoSection.header}}" stepKey="clickExpandSearchEngineOptimisation"/>
         <fillField selector="{{CmsNewPagePageSeoSection.urlKey}}" userInput="{{_duplicatedCMSPage.identifier}}" stepKey="fillFieldUrlKey"/>
+    </actionGroup>
+    <actionGroup name="SetCMSPageDisabled">
+        <seeElement selector="{{CmsNewPagePageBasicFieldsSection.isActive('1')}}" stepKey="seePageIsEnabled" />
+        <click selector="{{CmsNewPagePageBasicFieldsSection.isActiveLabel}}" stepKey="setPageDisabled"/>
+    </actionGroup>
+    <actionGroup name="SetCMSPageEnabled">
+        <seeElement selector="{{CmsNewPagePageBasicFieldsSection.isActive('0')}}" stepKey="seePageIsDisabled" />
+        <click selector="{{CmsNewPagePageBasicFieldsSection.isActiveLabel}}" stepKey="setPageEnabled"/>
+    </actionGroup>
+    <actionGroup name="SelectCMSPageStoreView">
+        <arguments>
+            <argument name="storeViewName" type="string"/>
+        </arguments>
+        <click selector="{{CmsNewPagePiwSection.header}}" stepKey="clickPageInWebsites"/>
+        <waitForElementVisible selector="{{CmsNewPagePiwSection.selectStoreView(storeViewName)}}" stepKey="waitForStoreGridReload"/>
+        <clickWithLeftButton selector="{{CmsNewPagePiwSection.selectStoreView(storeViewName)}}" stepKey="clickStoreView"/>
     </actionGroup>
 </actionGroups>

--- a/app/code/Magento/Cms/Test/Mftf/Section/CmsNewPagePageBasicFieldsSection.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Section/CmsNewPagePageBasicFieldsSection.xml
@@ -12,6 +12,7 @@
         <element name="pageTitle" type="input" selector="input[name=title]"/>
         <element name="RequiredFieldIndicator" type="text" selector=" return window.getComputedStyle(document.querySelector('._required[data-index=title]&gt;.admin__field-label span'), ':after').getPropertyValue('content');"/>
         <element name="isActive" type="button" selector="//input[@name='is_active' and @value='{{var1}}']" parameterized="true"/>
+        <element name="isActiveLabel" type="button" selector="div[data-index=is_active] .admin__actions-switch-label"/>
         <element name="duplicatedURLKey" type="input" selector="//input[contains(@data-value,'{{var1}}')]" parameterized="true"/>
     </section>
 </sections>

--- a/app/code/Magento/Cms/Test/Mftf/Section/CmsNewPagePiwSection.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Section/CmsNewPagePiwSection.xml
@@ -11,5 +11,6 @@
     <section name="CmsNewPagePiwSection">
         <element name="header" type="button" selector="div[data-index=websites]" timeout="30"/>
         <element name="selectStoreView" type="select" selector="//option[contains(text(),'{{var1}}')]" parameterized="true"/>
+        <element name="storeIdDropdown" type="select" selector="select[name='store_id']"/>
     </section>
 </sections>

--- a/app/code/Magento/Cms/Test/Mftf/Test/AdminCreateCmsPageEntityTest.xml
+++ b/app/code/Magento/Cms/Test/Mftf/Test/AdminCreateCmsPageEntityTest.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminCreateCmsPageEntityTest">
+        <annotations>
+            <features value="Cms"/>
+            <title value="Create CMS Page via the Admin"/>
+            <description value="Admin should be able to create a CMS Page"/>
+            <group value="backend"/>
+            <group value="cMSContent"/>
+            <group value="mtf_migrated"/>
+        </annotations>
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="loginAsAdmin"/>
+        </before>
+        <after>
+            <!--Disable single store mode-->
+            <magentoCLI command="config:set general/single_store_mode/enabled 0" stepKey="disableSingleStoreMode"/>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+
+        <!--Create CMS Content Page-->
+        <!--Go to New CMS Page page-->
+        <amOnPage url="{{CmsNewPagePage.url}}" stepKey="navigateToCreateNewPage"/>
+        <waitForPageLoad stepKey="waitForNewPagePageLoad"/>
+        <actionGroup ref="FillOutCMSPageContent" stepKey="fillBasicPageData"/>
+        <!--verify successfully saved-->
+        <actionGroup ref="saveCmsPage" stepKey="saveNewPage"/>
+        <!--verify page on frontend-->
+        <amOnPage url="{{StorefrontHomePage.url}}/{{_duplicatedCMSPage.identifier}}" stepKey="amOnPageTestPage"/>
+        <actionGroup ref="AssertStoreFrontCMSPage" stepKey="verifyPageDataOnFrontend">
+            <argument name="cmsTitle" value="{{_duplicatedCMSPage.title}}"/>
+            <argument name="cmsContent" value="{{_duplicatedCMSPage.content}}"/>
+            <argument name="cmsContentHeading" value="{{_duplicatedCMSPage.content_heading}}"/>
+        </actionGroup>
+        <!--verify page in grid-->
+        <actionGroup ref="navigateToCreatedCMSPage" stepKey="verifyPageInGrid">
+            <argument name="CMSPage" value="_duplicatedCMSPage"/>
+        </actionGroup>
+        <actionGroup ref="DeletePageByUrlKeyActionGroup" stepKey="deletePage">
+            <argument name="UrlKey" value="{{_duplicatedCMSPage.identifier}}"/>
+        </actionGroup>
+
+        <!--Create page for default store view-->
+        <!--Go to New CMS Page page-->
+        <amOnPage url="{{CmsNewPagePage.url}}" stepKey="navigateToCreateNewPage2"/>
+        <waitForPageLoad stepKey="waitForNewPagePageLoad2"/>
+        <!--Fill the CMS page form-->
+        <actionGroup ref="FillOutCMSPageContent" stepKey="fillBasicPageDataForPageWithDefaultStore"/>
+        <actionGroup ref="SelectCMSPageStoreView" stepKey="selectCMSPageStoreView">
+            <argument name="storeViewName" value="Default Store View"/>
+        </actionGroup>
+        <!--Verify successfully saved-->
+        <actionGroup ref="saveCmsPage" stepKey="savePageWithDefaultStore"/>
+        <!--Navigate to page in Admin-->
+        <actionGroup ref="navigateToCreatedCMSPage" stepKey="navigateToCMSPageWithDefaultStoreInAdmin">
+            <argument name="CMSPage" value="_duplicatedCMSPage"/>
+        </actionGroup>
+        <!--Verify Page Data in Admin-->
+        <actionGroup ref="AssertCMSPageContent" stepKey="verifyPageWithDefaultStoreDataInAdmin"/>
+        <!--Verify Store ID-->
+        <actionGroup ref="AssertCMSPageStoreId" stepKey="verifyStoreId">
+            <argument name="storeId" value="1"/>
+        </actionGroup>
+        <!--Delete page-->
+        <actionGroup ref="DeletePageByUrlKeyActionGroup" stepKey="deletePageWithDefaultStore">
+            <argument name="UrlKey" value="{{_duplicatedCMSPage.identifier}}"/>
+        </actionGroup>
+
+        <!--Block Cache Exploit-->
+        <!--Go to New CMS Page page-->
+        <amOnPage url="{{CmsNewPagePage.url}}" stepKey="navigateToCreateNewPage3"/>
+        <waitForPageLoad stepKey="waitForNewPagePageLoad3"/>
+        <!--Fill the CMS page form-->
+        <actionGroup ref="FillOutCMSPageContent" stepKey="fillBasicPageDataForPageWithBlock"/>
+        <fillField selector="{{CmsNewPagePageContentSection.content}}" userInput="{{block class=&apos;Magento\Framework\View\Element\Text&apos; text=&apos;bla bla bla&apos; cache_key=&apos;BACKEND_ACL_RESOURCES&apos; cache_lifetime=999}}" stepKey="fillFieldContent"/>
+        <actionGroup ref="SelectCMSPageStoreView" stepKey="selectCMSPageStoreViewForPageWithBlock">
+            <argument name="storeViewName" value="Default Store View"/>
+        </actionGroup>
+        <!--Verify successfully saved-->
+        <actionGroup ref="saveCmsPage" stepKey="savePageWithBlock"/>
+        <!--verify page on frontend-->
+        <amOnPage url="{{StorefrontHomePage.url}}/{{_duplicatedCMSPage.identifier}}" stepKey="amOnPageWithBlock"/>
+        <actionGroup ref="AssertStoreFrontCMSPage" stepKey="verifyPageWithBlockDataOnFrontend">
+            <argument name="cmsTitle" value="{{_duplicatedCMSPage.title}}"/>
+            <argument name="cmsContent" value="bla bla bla"/>
+            <argument name="cmsContentHeading" value="{{_duplicatedCMSPage.content_heading}}"/>
+        </actionGroup>
+        <!--Delete page with block-->
+        <actionGroup ref="DeletePageByUrlKeyActionGroup" stepKey="deletePageWithBlock">
+            <argument name="UrlKey" value="{{_duplicatedCMSPage.identifier}}"/>
+        </actionGroup>
+
+        <!--Create CMS page with single store mode-->
+        <!--Enable single store mode-->
+        <magentoCLI command="config:set general/single_store_mode/enabled 1" stepKey="enableSingleStoreMode"/>
+        <!--Go to New CMS Page page-->
+        <amOnPage url="{{CmsNewPagePage.url}}" stepKey="navigateToCreateNewPage4"/>
+        <waitForPageLoad stepKey="waitForNewPagePageLoad4"/>
+        <!--Fill the CMS page form-->
+        <actionGroup ref="FillOutCMSPageContent" stepKey="fillBasicPageDataInSingleStoreMode"/>
+        <!--Verify successfully saved-->
+        <actionGroup ref="saveCmsPage" stepKey="savePageInSingleStoreMode"/>
+        <!--verify page on frontend-->
+        <amOnPage url="{{StorefrontHomePage.url}}/{{_duplicatedCMSPage.identifier}}" stepKey="amOnPageTestPageInSingleStoreMode"/>
+        <actionGroup ref="AssertStoreFrontCMSPage" stepKey="verifyPageDataOnFrontendInSingleStoreMode">
+            <argument name="cmsTitle" value="{{_duplicatedCMSPage.title}}"/>
+            <argument name="cmsContent" value="{{_duplicatedCMSPage.content}}"/>
+            <argument name="cmsContentHeading" value="{{_duplicatedCMSPage.content_heading}}"/>
+        </actionGroup>
+        <!--Navigate to page in Admin-->
+        <actionGroup ref="navigateToCreatedCMSPage" stepKey="navigateToCMSPageInAdminInSingleStoreMode">
+            <argument name="CMSPage" value="_duplicatedCMSPage"/>
+        </actionGroup>
+        <!--Verify Page Data in Admin-->
+        <actionGroup ref="AssertCMSPageContent" stepKey="verifyPageDataInAdminInSingleStoreMode"/>
+        <!--Delete page-->
+        <actionGroup ref="DeletePageByUrlKeyActionGroup" stepKey="deletePageInSingleStoreMode">
+            <argument name="UrlKey" value="{{_duplicatedCMSPage.identifier}}"/>
+        </actionGroup>
+
+        <!--Create disabled page-->
+        <!--Go to New CMS Page page-->
+        <amOnPage url="{{CmsNewPagePage.url}}" stepKey="navigateToCreateNewPage5"/>
+        <waitForPageLoad stepKey="waitForNewPagePageLoad5"/>
+        <!--Fill the CMS page form-->
+        <actionGroup ref="FillOutCMSPageContent" stepKey="fillBasicPageDataForDisabledPage"/>
+        <actionGroup ref="SetCMSPageDisabled" stepKey="setCMSPageDisabled"/>
+        <!--Verify successfully saved-->
+        <actionGroup ref="saveCmsPage" stepKey="saveDisabledPage"/>
+        <!--Check that page is disabled on frontend-->
+        <amOnPage url="{{StorefrontHomePage.url}}/{{_duplicatedCMSPage.identifier}}" stepKey="amOnDeactivatedPageOnFrontend"/>
+        <waitForPageLoad stepKey="waitForDeactivatedPageLoadOnFrontend"/>
+        <see userInput="Whoops, our bad..." stepKey="seePageError"/>
+        <!--Delete page-->
+        <actionGroup ref="DeletePageByUrlKeyActionGroup" stepKey="deleteDisabledPage">
+            <argument name="UrlKey" value="{{_duplicatedCMSPage.identifier}}"/>
+        </actionGroup>
+    </test>
+</tests>


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
This PR introduces functional test coverage for CMS page create.

Variations covered:
- Create CMS Content Page
- Create CMS Page for default store view
- Create CMS Page With Block
- Create CMS page in single store mode
- Create disabled page

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento-functional-tests-migration#631: Convert CreateCmsPageEntityTest to MFTF
