### PR TITLE
Delete Product URL Rewrite

### DIFF
--- a/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminDeleteProductURLRewriteEntityTest.xml
+++ b/app/code/Magento/UrlRewrite/Test/Mftf/Test/AdminDeleteProductURLRewriteEntityTest.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ /**
+  * Copyright © Magento, Inc. All rights reserved.
+  * See COPYING.txt for license details.
+  */
+-->
+<tests xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:noNamespaceSchemaLocation="urn:magento:mftf:Test/etc/testSchema.xsd">
+    <test name="AdminDeleteProductURLRewriteEntityTest">
+        <annotations>
+            <stories value="Delete Product UrlRewrite"/>
+            <title value="Delete created product URL rewrite"/>
+            <description value="Login as admin, create product with category and UrlRewrite, delete created URL rewrite"/>
+            <group value="mtf_migrated"/>
+        </annotations>
+
+        <before>
+            <actionGroup ref="LoginAsAdmin" stepKey="login"/>
+            <createData entity="SimpleSubCategory" stepKey="createCategory"/>
+            <createData entity="SimpleProduct" stepKey="createSimpleProduct">
+                <requiredEntity createDataKey="createCategory"/>
+            </createData>
+        </before>
+        <after>
+            <deleteData createDataKey="createCategory" stepKey="deleteCategory"/>
+            <deleteData createDataKey="createSimpleProduct" stepKey="deleteProduct"/>
+            <actionGroup ref="logout" stepKey="logout"/>
+        </after>
+
+        <!--Filter and Select the created Product -->
+        <actionGroup ref="AdminSearchUrlRewriteProductBySkuActionGroup" stepKey="searchProduct">
+            <argument name="productSku" value="$$createSimpleProduct.sku$$"/>
+        </actionGroup>
+
+        <!-- Update the Store, RequestPath, RedirectType and Description -->
+        <actionGroup ref="AdminAddUrlRewriteForProductActionGroup" stepKey="addUrlRewrite">
+            <argument name="storeValue" value="Default Store View"/>
+            <argument name="requestPath" value="{{FirstLevelSubCat.name_lwr}}/{{_defaultProduct.urlKey}}.html"/>
+            <argument name="redirectTypeValue" value="Temporary (302)"/>
+            <argument name="description" value="End To End Test"/>
+        </actionGroup>
+
+        <!--Delete Created Rewrite, Assert Success Message -->
+        <actionGroup ref="AdminDeleteUrlRewriteActionGroup" stepKey="deleteCreatedRewrite">
+            <argument name="requestPath" value="{{FirstLevelSubCat.name_lwr}}/{{_defaultProduct.urlKey}}.html"/>
+        </actionGroup>
+        <!-- Assert Deleted Rewrite is Not in Grid -->
+        <actionGroup ref="AdminSearchDeletedUrlRewriteActionGroup" stepKey="searchDeletedURLRewriteInGrid">
+            <argument name="requestPath" value="{{FirstLevelSubCat.name_lwr}}/{{_defaultProduct.urlKey}}.html"/>
+        </actionGroup>
+        <!-- Assert Page By Url Rewrite is Not Found -->
+        <actionGroup ref="AssertPageByUrlRewriteIsNotFoundActionGroup" stepKey="amOnPage">
+            <argument name="requestPath" value="{{FirstLevelSubCat.name_lwr}}/{{_defaultProduct.urlKey}}.html"/>
+        </actionGroup>
+    </test>
+</tests>

--- a/dev/tests/functional/tests/app/Magento/UrlRewrite/Test/TestCase/DeleteProductUrlRewriteEntityTest.xml
+++ b/dev/tests/functional/tests/app/Magento/UrlRewrite/Test/TestCase/DeleteProductUrlRewriteEntityTest.xml
@@ -8,6 +8,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../../vendor/magento/mtf/etc/variations.xsd">
     <testCase name="Magento\UrlRewrite\Test\TestCase\DeleteProductUrlRewriteEntityTest" summary="Delete Product URL Rewrites" ticketId="MAGETWO-23287">
         <variation name="DeleteProductUrlRewriteEntityTestVariation1">
+            <data name="tag" xsi:type="string">mftf_migrated:yes</data>
             <data name="productRedirect/dataset" xsi:type="string">default_without_target</data>
             <data name="productRedirect/data/target_path/entity" xsi:type="string">product/%catalogProductSimple::product_100_dollar%</data>
             <constraint name="Magento\UrlRewrite\Test\Constraint\AssertUrlRewriteDeletedMessage" />


### PR DESCRIPTION
**Description**
This PR with a test that deletes product's URL Rewrite

**Steps:**
Sub category is created.
Product is created.
Create Product URL Rewrite
Find Created Rewrite in Grid
Click Redirect from grid.
Click 'Delete' button.
Perform asserts.

**Fixed issues**
#665 Convert DeleteProductUrlRewriteEntityTest to MFTF